### PR TITLE
extended test factory to allow request body

### DIFF
--- a/csharp-visualstudio/Functions.Tests/TestFactory.cs
+++ b/csharp-visualstudio/Functions.Tests/TestFactory.cs
@@ -29,15 +29,28 @@ namespace Functions.Tests
             return qs;
         }
 
-        public static DefaultHttpRequest CreateHttpRequest(string queryStringKey, string queryStringValue)
+        public static DefaultHttpRequest CreateHttpRequest(string queryStringKey, string queryStringValue, string body = null)
         {
             var request = new DefaultHttpRequest(new DefaultHttpContext())
             {
                 Query = new QueryCollection(CreateDictionary(queryStringKey, queryStringValue))
             };
+
+            if (body != null)
+            {
+                using (var stream = new MemoryStream())
+                using (var writer = new StreamWriter(stream))
+                {
+                    writer.Write(body);
+                    writer.Flush();
+                    stream.Position = 0;
+                    request.Body = stream;
+                }
+            }
+
             return request;
         }
-
+        
         public static ILogger CreateLogger(LoggerTypes type = LoggerTypes.Null)
         {
             ILogger logger;

--- a/csharp-visualstudio/Functions.Tests/TestFactory.cs
+++ b/csharp-visualstudio/Functions.Tests/TestFactory.cs
@@ -38,14 +38,12 @@ namespace Functions.Tests
 
             if (body != null)
             {
-                using (var stream = new MemoryStream())
-                using (var writer = new StreamWriter(stream))
-                {
-                    writer.Write(body);
-                    writer.Flush();
-                    stream.Position = 0;
-                    request.Body = stream;
-                }
+                var stream = new MemoryStream();
+                var writer = new StreamWriter(stream);
+                writer.Write(body);
+                writer.Flush();
+                stream.Position = 0;
+                request.Body = stream;
             }
 
             return request;

--- a/csharp-visualstudio/Functions.Tests/TestFactory.cs
+++ b/csharp-visualstudio/Functions.Tests/TestFactory.cs
@@ -29,12 +29,12 @@ namespace Functions.Tests
             return qs;
         }
 
-        public static DefaultHttpRequest CreateHttpRequest(string queryStringKey, string queryStringValue, string body = null)
+        public static DefaultHttpRequest CreateHttpRequest(string queryStringKey = null, string queryStringValue = null, string body = null)
         {
-            var request = new DefaultHttpRequest(new DefaultHttpContext())
-            {
-                Query = new QueryCollection(CreateDictionary(queryStringKey, queryStringValue))
-            };
+            var request = new DefaultHttpRequest(new DefaultHttpContext());
+
+            if (!string.IsNullOrEmpty(queryStringKey) && !string.IsNullOrEmpty(queryStringValue))
+                request.Query = new QueryCollection(CreateDictionary(queryStringKey, queryStringValue));
 
             if (body != null)
             {


### PR DESCRIPTION
We can now test the request body being sent to out azure functions

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
It will allow anyone using the test factory to mock a post request to the function

## Does this introduce a breaking change?
No this is an extension and will cause no breaking changes
```
[ ] Yes
[ x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

Use the optional param 

  var request = TestFactory.CreateHttpRequest( body:"SomeContent");


Fixes issue https://github.com/MicrosoftDocs/azure-docs/issues/43553

